### PR TITLE
test: HAR recorded in "attach" mode should have content in the entries

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { defaultMatcher } from "./utils/matchers/defaultMatcher";
 export { Matcher, AdvancedRouteFromHAR } from "./utils/types";
 export { defaultMatcher } from "./utils/matchers/defaultMatcher";
 export { customMatcher } from "./utils/matchers/customMatcher";
+export { parseContent } from "./utils/serveFromHar";
 import * as path from "path";
 
 export const test = base.extend<{

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -2,7 +2,7 @@ import type { APIResponse, Request, Route, Cookie } from "@playwright/test";
 import type { Entry } from "har-format";
 import type { findEntry } from "./serveFromHar";
 
-export type Matcher = (request: Request, entry: Entry) => number;
+export type Matcher = (request: Request, entry: Entry) => number | Promise<number>;
 
 export type AdvancedMatcher = {
 	findEntry?: typeof findEntry;

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -33,3 +33,11 @@ test("record test with a joke and postprocess", async ({ page, advancedRouteFrom
 	await page.waitForSelector("text=This is a joke");
 	await page.close();
 });
+
+
+test("record not embedded", async ({ page, advancedRouteFromHAR }) => {
+	await advancedRouteFromHAR("tests/har/temp/not-embedded.har", {
+		update: true,
+	});
+	await page.goto("https://v2.jokeapi.dev/joke/Any?blacklistFlags=nsfw,religious,political,racist,sexist,explicit");
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -35,7 +35,7 @@ test("record test with a joke and postprocess", async ({ page, advancedRouteFrom
 });
 
 
-test("record not embedded", async ({ page, advancedRouteFromHAR }) => {
+test("record attached (not embedded)", async ({ page, advancedRouteFromHAR }) => {
 	await advancedRouteFromHAR("tests/har/temp/not-embedded.har", {
 		update: true,
 	});

--- a/tests/test.spec.ts
+++ b/tests/test.spec.ts
@@ -171,6 +171,16 @@ async function waitForFile(path: string) {
 	throw "can't read file";
 }
 
+test("attached content", async ({ page, advancedRouteFromHAR }) => {
+	await advancedRouteFromHAR("tests/har/temp/not-embedded.har", {
+		matcher: (request, entry) => {
+			expect(entry.response.content.text).toBeTruthy();
+			return defaultMatcher(request, entry);
+		}
+	});
+	await page.goto("https://v2.jokeapi.dev/joke/Any?blacklistFlags=nsfw,religious,political,racist,sexist,explicit");
+});
+
 test("test a joke recording with postprocess", async ({ page, advancedRouteFromHAR }) => {
 	await advancedRouteFromHAR("tests/har/temp/joke-postprocess.har", {
 		update: true,


### PR DESCRIPTION
1. Matchers can now return a promise
2. the `readContent` function is now exported :)