### PR TITLE
feat: export advancedRouteFromHAR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@types/har-format": "^1.2.14"
 			},
 			"devDependencies": {
-				"@playwright/test": "^1.39.0",
+				"@playwright/test": "^1.49.0",
 				"@types/node": "^22.9.3",
 				"@typescript-eslint/eslint-plugin": "^8.18.1",
 				"@typescript-eslint/parser": "^8.18.1",
@@ -21,6 +21,9 @@
 				"eslint-plugin-prettier": "^5.0.1",
 				"prettier": "^3.0.3",
 				"typescript": "^5.7.2"
+			},
+			"peerDependencies": {
+				"playwright": "^1.35.0"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
@@ -945,7 +948,6 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
 			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-			"dev": true,
 			"hasInstallScript": true,
 			"optional": true,
 			"os": [
@@ -1343,7 +1345,6 @@
 			"version": "1.49.1",
 			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
 			"integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
-			"dev": true,
 			"dependencies": {
 				"playwright-core": "1.49.1"
 			},
@@ -1361,7 +1362,6 @@
 			"version": "1.49.1",
 			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
 			"integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
-			"dev": true,
 			"bin": {
 				"playwright-core": "cli.js"
 			},

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { test as base } from "@playwright/test";
+import { test as base, Page } from "@playwright/test";
 import * as fs from "fs";
 import { AdvancedRouteFromHAR, requestResponseToEntry } from "./utils/types";
 import { parseContent, serveFromHar } from "./utils/serveFromHar";
@@ -9,47 +9,53 @@ export { customMatcher } from "./utils/matchers/customMatcher";
 export { parseContent } from "./utils/serveFromHar";
 import * as path from "path";
 
+export const advancedRouteFromHAR = async (
+	{ page }: { page: Page },
+	use: (fn: AdvancedRouteFromHAR) => Promise<void>,
+) => {
+	const originalRouteFromHAR = page.routeFromHAR.bind(page);
+
+	await use(async (filename, options) => {
+		if (options?.update) {
+			const { matcher } = options;
+			if (matcher && "postProcess" in matcher) {
+				await page.route(options.url || /.*/, async (route, request) => {
+					const resp = await route.fetch();
+					const response = matcher.postProcess?.(
+						await requestResponseToEntry(request, resp, await page.context().cookies()),
+					).response;
+					if (response)
+						route.fulfill({
+							status: response.status,
+							headers: Object.fromEntries(response.headers.map((header) => [header.name, header.value])),
+							body: await parseContent(response.content, path.dirname(filename)),
+						});
+				});
+			}
+			// on update, we want to record the HAR just like the original playwright method
+			return originalRouteFromHAR(filename, {
+				url: options.url,
+				update: true,
+				updateContent: options?.updateContent,
+				updateMode: options?.updateMode,
+			});
+		} else {
+			const har = JSON.parse(await fs.promises.readFile(filename, { encoding: "utf8" }));
+			return serveFromHar(
+				har,
+				{
+					...options,
+					matcher: options?.matcher ?? defaultMatcher,
+					dirName: path.dirname(filename),
+				},
+				page,
+			);
+		}
+	});
+};
+
 export const test = base.extend<{
 	advancedRouteFromHAR: AdvancedRouteFromHAR;
 }>({
-	advancedRouteFromHAR: async ({ page }, use) => {
-		const originalRouteFromHAR = page.routeFromHAR.bind(page);
-		const advancedRouteFromHAR: AdvancedRouteFromHAR = async (filename, options) => {
-			if (options?.update) {
-				const {matcher} = options;
-				if (matcher && "postProcess" in matcher) {
-					await page.route(options.url || /.*/, async (route, request) => {
-						const resp = await route.fetch();
-						const response = matcher.postProcess?.(await requestResponseToEntry(request, resp, await page.context().cookies())).response;
-						if(response)
-							route.fulfill({
-								status: response.status,
-								headers: Object.fromEntries(response.headers.map((header) => [header.name, header.value])),
-								body: await parseContent(response.content, path.dirname(filename)),
-							});
-					});
-				}
-				// on update, we want to record the HAR just like the original playwright method
-				return originalRouteFromHAR(filename, {
-					url: options.url,
-					update: true,
-					updateContent: options?.updateContent,
-					updateMode: options?.updateMode,
-				});
-			} else {
-				const har = JSON.parse(await fs.promises.readFile(filename, { encoding: "utf8" }));
-				return serveFromHar(
-					har,
-					{
-						...options,
-						matcher: options?.matcher ?? defaultMatcher,
-						dirName: path.dirname(filename),
-					},
-					page,
-				);
-			}
-		};
-
-		await use(advancedRouteFromHAR);
-	},
+	advancedRouteFromHAR,
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { test as base, Page } from "@playwright/test";
+import { test as base, type Page } from "@playwright/test";
 import * as fs from "fs";
 import { AdvancedRouteFromHAR, requestResponseToEntry } from "./utils/types";
 import { parseContent, serveFromHar } from "./utils/serveFromHar";


### PR DESCRIPTION
allows usable via import. this is useful when you want to use this in a utility file that exports a wrapped version of this with defaults set.

fixes https://github.com/NoamGaash/playwright-advanced-har/issues/71