### PR TITLE
ci: allow Claude to run bash commands without approval

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,9 +19,9 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
@@ -46,5 +46,5 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          claude_args: '--dangerously-skip-permissions'
 


### PR DESCRIPTION
## Summary

- Enable `--dangerously-skip-permissions` so Claude can run `npm install`, `git` commands, etc. in CI without requiring interactive approval
- Upgrade `contents`, `pull-requests`, and `issues` permissions from `read` to `write` so Claude can push commits and update PRs/issues

## Why

Previously Claude could analyze problems but couldn't apply fixes because running bash scripts required user approval — which isn't possible in an automated CI environment. This was the root cause of [#122](https://github.com/NoamGaash/playwright-advanced-har/pull/122#issuecomment-3984934455) where Claude identified the fix but couldn't execute it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)