### PR TITLE
fix: restore playwright peer dep to ^1.35.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
 				"typescript": "^5.9.3"
 			},
 			"peerDependencies": {
-				"playwright": "^1.58.2"
+				"playwright": "^1.35.0"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"typescript": "^5.9.3"
 	},
 	"peerDependencies": {
-		"playwright": "^1.58.2"
+		"playwright": "^1.35.0"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
pushed as "fix" to release a new version with all security updates
-----------

Reverts the playwright peer dependency from ^1.58.2 back to ^1.35.0 to maintain support for older playwright versions.

Related to #126.

Generated with [Claude Code](https://claude.ai/code)